### PR TITLE
refactor: Rewrite net client to ease logging

### DIFF
--- a/GetAssetTrigger/index.ts
+++ b/GetAssetTrigger/index.ts
@@ -13,7 +13,7 @@ import { makeResult } from "../lib/net/make_result"
 
 const GetAssetTrigger: AzureFunction = async function (context: Context, req: HttpRequest): Promise<void> {
   const { id } = context.bindingData
-  const collibraClient = makeCollibraClient({ headers: { authorization: req.headers.authorization } })
+  const collibraClient = makeCollibraClient(req.headers.authorization)
 
   const res = await pipe(
     getAssetByID(collibraClient)(id),

--- a/GetMaintainersTrigger/index.ts
+++ b/GetMaintainersTrigger/index.ts
@@ -15,7 +15,7 @@ import { isErrorResult } from "../lib/net/is_error_result"
 import { makeResult } from "../lib/net/make_result"
 
 const GetMaintainersTrigger: AzureFunction = async function (context: Context, req: HttpRequest): Promise<void> {
-  const collibraClient = makeCollibraClient({ headers: { authorization: req.headers.authorization } })
+  const collibraClient = makeCollibraClient(req.headers.authorization)
   const { id } = context.bindingData
   const groups: string[] = req.query.group?.split(",") ?? []
 

--- a/GetTermsAndConditionsTrigger/index.ts
+++ b/GetTermsAndConditionsTrigger/index.ts
@@ -12,9 +12,7 @@ import { isErrorResult } from "../lib/net/is_error_result"
 import { makeResult } from "../lib/net/make_result"
 
 const GetTermsAndConditionTrigger: AzureFunction = async function (context: Context, req: HttpRequest): Promise<void> {
-  const collibraClient = makeCollibraClient({
-    headers: { authorization: req.headers.authorization },
-  })
+  const collibraClient = makeCollibraClient(req.headers.authorization)
 
   const { id } = context.bindingData
 

--- a/app.d.ts
+++ b/app.d.ts
@@ -18,8 +18,6 @@ declare global {
 
     export interface Client {
       request: <T>(url: string, opts?: RequestOpts) => Promise<T>
-      get?: <T>(url: string, opts?: Omit<RequestOpts, "method" | "body">) => Promise<T>
-      post?: <T>(url: string, opts?: Omit<RequestOpts, "method">) => Promise<T>
     }
 
     type Result<T, E extends Error> = {

--- a/app.d.ts
+++ b/app.d.ts
@@ -11,9 +11,15 @@ declare global {
       body: any
     }>
 
+    export type ClientConfig = Partial<{
+      baseURL: string
+      headers: Record<string, OutgoingHttpHeader>
+    }>
+
     export interface Client {
-      get<T>(url: string, opts?: Omit<RequestOpts, "method" | "body">): Promise<T>
-      post<T>(url: string, opts?: Omit<RequestOpts, "method">): Promise<T>
+      request: <T>(url: string, opts?: RequestOpts) => Promise<T>
+      get?: <T>(url: string, opts?: Omit<RequestOpts, "method" | "body">) => Promise<T>
+      post?: <T>(url: string, opts?: Omit<RequestOpts, "method">) => Promise<T>
     }
 
     type Result<T, E extends Error> = {

--- a/lib/collibra/client/get_asset_attributes.ts
+++ b/lib/collibra/client/get_asset_attributes.ts
@@ -1,17 +1,17 @@
-import { AxiosInstance } from "axios"
 import * as E from "fp-ts/Either"
 import * as TE from "fp-ts/TaskEither"
-import { pipe } from "fp-ts/lib/function"
+import { pipe } from "fp-ts/function"
 
-export const getAssetAttributes = (client: AxiosInstance) => (id: string) =>
+import { Get } from "../../net/get"
+
+export const getAssetAttributes = (client: Net.Client) => (id: string) =>
   pipe(
     TE.tryCatch(
       () =>
-        client.request<Collibra.PagedAttributeResponse>({
-          url: "/attributes",
+        Get<Collibra.PagedAttributeResponse>(client)("/attributes", {
           params: new URLSearchParams({ assetId: id }),
         }),
       E.toError
     ),
-    TE.map(({ data }) => data.results)
+    TE.map((res) => res.results)
   )

--- a/lib/collibra/client/get_asset_by_id.ts
+++ b/lib/collibra/client/get_asset_by_id.ts
@@ -1,10 +1,7 @@
-import { AxiosResponse } from "axios"
 import * as E from "fp-ts/Either"
 import * as TE from "fp-ts/TaskEither"
-import { pipe } from "fp-ts/lib/function"
+
+import { Get } from "../../net/get"
 
 export const getAssetByID = (client: Net.Client) => (id: string) =>
-  pipe(
-    TE.tryCatch(() => client.get<AxiosResponse<Collibra.Asset>>(`/assets/${id}`), E.toError),
-    TE.map(({ data }) => data)
-  )
+  TE.tryCatch(() => Get<Collibra.Asset>(client)(`/assets/${id}`), E.toError)

--- a/lib/collibra/client/get_asset_responsibilities.ts
+++ b/lib/collibra/client/get_asset_responsibilities.ts
@@ -1,18 +1,19 @@
-import type { AxiosResponse } from "axios"
 import * as E from "fp-ts/Either"
 import * as TE from "fp-ts/TaskEither"
 import { pipe } from "fp-ts/function"
 
-type ResponsibilitiesResponse = AxiosResponse<Collibra.PagedResponsibilityResponse>
-const _getResponsibilities = (client: Net.Client, id: string) => () =>
-  client.get<ResponsibilitiesResponse>("/responsibilities", {
-    params: new URLSearchParams({ resourceIds: id }),
-  })
+import { Get } from "../../net/get"
 
 export const getAssetResponsibilities =
   (client: Net.Client) =>
   (id: string): TE.TaskEither<Error, Collibra.Responsibility[]> =>
     pipe(
-      TE.tryCatch(_getResponsibilities(client, id), E.toError),
-      TE.map(({ data }) => data.results)
+      TE.tryCatch(
+        () =>
+          Get<Collibra.PagedResponsibilityResponse>(client)("/responsibilities", {
+            params: new URLSearchParams({ resourceIds: id }),
+          }),
+        E.toError
+      ),
+      TE.map(({ results }) => results)
     )

--- a/lib/collibra/client/get_roles_by_names.ts
+++ b/lib/collibra/client/get_roles_by_names.ts
@@ -1,16 +1,17 @@
-import { AxiosResponse } from "axios"
 import * as A from "fp-ts/Array"
 import * as E from "fp-ts/Either"
 import * as TE from "fp-ts/TaskEither"
 import { pipe } from "fp-ts/function"
 
-type RolesResponse = AxiosResponse<Collibra.PagedResponse<Collibra.Role>>
+import { Get } from "../../net/get"
+
+type RolesResponse = Collibra.PagedResponse<Collibra.Role>
 
 export const getRolesByNames =
   (client: Net.Client) =>
   (names: string[]): TE.TaskEither<Error, Collibra.Role[]> =>
     pipe(
-      TE.tryCatch(() => client.get<RolesResponse>("/roles"), E.toError),
-      TE.map(({ data }) => data.results),
+      TE.tryCatch(() => Get<RolesResponse>(client)("/roles"), E.toError),
+      TE.map(({ results }) => results),
       TE.map(A.filter((r) => names.length === 0 || names.includes(r.name)))
     )

--- a/lib/collibra/client/get_user.ts
+++ b/lib/collibra/client/get_user.ts
@@ -1,13 +1,7 @@
-import { AxiosResponse } from "axios"
 import * as E from "fp-ts/Either"
 import * as TE from "fp-ts/TaskEither"
-import { pipe } from "fp-ts/function"
 
-type UserResponse = AxiosResponse<Readonly<Collibra.User>>
-const _getUser = (client: Net.Client, id: string) => () => client.get<UserResponse>(`/users/${id}`)
+import { Get } from "../../net/get"
 
 export const getUser = (client: Net.Client) => (id: string) =>
-  pipe(
-    TE.tryCatch(_getUser(client, id), E.toError),
-    TE.map(({ data }) => data)
-  )
+  TE.tryCatch(() => Get<Collibra.User>(client)(`/users/${id}`), E.toError)

--- a/lib/collibra/client/get_users_by_id_batch.ts
+++ b/lib/collibra/client/get_users_by_id_batch.ts
@@ -1,12 +1,12 @@
-import type { AxiosResponse } from "axios"
 import * as A from "fp-ts/Array"
 import * as E from "fp-ts/Either"
 import * as TE from "fp-ts/TaskEither"
 import { pipe } from "fp-ts/function"
 
-type UsersResponse = AxiosResponse<Collibra.PagedUserResponse>
+import { Get } from "../../net/get"
+
 const getUsers = (client: Net.Client) => (params: URLSearchParams) =>
-  TE.tryCatch(() => client.get<UsersResponse>("/users", { params }), E.toError)
+  TE.tryCatch(() => Get<Collibra.PagedUserResponse>(client)("/users", { params }), E.toError)
 
 export const getUsersByIdBatch =
   (client: Net.Client) =>
@@ -21,5 +21,5 @@ export const getUsersByIdBatch =
       ),
       TE.mapLeft((err) => new Error(err)),
       TE.chain(getUsers(client)),
-      TE.map((res) => res.data.results)
+      TE.map(({ results }) => results)
     )

--- a/lib/collibra/client/make_collibra_client.ts
+++ b/lib/collibra/client/make_collibra_client.ts
@@ -1,14 +1,7 @@
-import axios, { type Axios, CreateAxiosDefaults } from "axios"
+import { makeNetClient } from "../../net/make_net_client"
 
-import { config } from "../../../config"
-
-export type RequesterFn<T> = (client: Axios) => (...args: any) => Promise<T>
-
-type ClientConfig = Omit<CreateAxiosDefaults, "url" | "baseURL" | "adapter">
-
-export const makeCollibraClient = (cfg: ClientConfig) => {
-  return axios.create({
-    ...cfg,
-    baseURL: config.COLLIBRA_BASE_URL,
+export const makeCollibraClient = (authorization: string) =>
+  makeNetClient({
+    baseURL: process.env.COLLIRBA_BASE_URL,
+    headers: { authorization },
   })
-}

--- a/lib/collibra/client/make_collibra_client.ts
+++ b/lib/collibra/client/make_collibra_client.ts
@@ -1,7 +1,8 @@
+import { config } from "../../../config"
 import { makeNetClient } from "../../net/make_net_client"
 
 export const makeCollibraClient = (authorization: string) =>
   makeNetClient({
-    baseURL: process.env.COLLIRBA_BASE_URL,
+    baseURL: config.COLLIBRA_BASE_URL,
     headers: { authorization },
   })

--- a/lib/net/get.ts
+++ b/lib/net/get.ts
@@ -1,0 +1,8 @@
+export const Get =
+  <T>(client: Net.Client) =>
+  (url: string, opts?: Omit<Net.RequestOpts, "method" | "body">): Promise<T> => {
+    return client.request<T>(url, {
+      ...opts,
+      method: "GET",
+    })
+  }

--- a/lib/net/make_net_client.ts
+++ b/lib/net/make_net_client.ts
@@ -14,10 +14,8 @@ export const makeNetClient = (cfg: Net.ClientConfig): Net.Client => {
     request: async <T>(url: string, opts?: Net.RequestOpts): Promise<T> => {
       const _baseURL = new URL(trimTrailingSlash(cfg.baseURL))
       const _url = new URL(
-        _baseURL.pathname
-          ? `${_baseURL.pathname}/${trimLeftRightSlashes(url)}${opts.params ? `?${opts.params.toString()}` : ""}`
-          : `${trimLeftRightSlashes(url)}${opts.params ? `?${opts.params.toString()}` : ""}`,
-        _baseURL
+        trimLeftRightSlashes(url),
+        `${trimTrailingSlash(_baseURL.href)}/` // just to guarantee that the url has a trailing slash
       )
 
       const _opts = {

--- a/lib/net/make_net_client.ts
+++ b/lib/net/make_net_client.ts
@@ -1,0 +1,48 @@
+import axios from "axios"
+import { pipe } from "fp-ts/lib/function"
+
+const DEFAULT_REQUEST_OPTS: Net.RequestOpts = {
+  method: "GET",
+}
+
+const trimLeadingSlash = (url: string) => (url[0] === "/" ? url.slice(1, url.length) : url)
+const trimTrailingSlash = (url: string) => (url[url.length - 1] === "/" ? url.slice(0, url.length - 1) : url)
+const trimLeftRightSlashes = (url: string) => pipe(url, trimLeadingSlash, trimTrailingSlash)
+
+export const makeNetClient = (cfg: Net.ClientConfig): Net.Client => {
+  return {
+    request: async <T>(url: string, opts?: Net.RequestOpts): Promise<T> => {
+      const _baseURL = new URL(trimTrailingSlash(cfg.baseURL))
+      const _url = new URL(
+        _baseURL.pathname
+          ? `${_baseURL.pathname}/${trimLeftRightSlashes(url)}${opts.params ? `?${opts.params.toString()}` : ""}`
+          : `${trimLeftRightSlashes(url)}${opts.params ? `?${opts.params.toString()}` : ""}`,
+        _baseURL
+      )
+
+      const _opts = {
+        ...DEFAULT_REQUEST_OPTS,
+        ...opts,
+      }
+
+      console.info(`[client.request] ${_opts.method} to ${_url.toString()}`)
+
+      try {
+        const { data } = await axios.request<T>({
+          url: _url.toString(),
+          headers: {
+            ...cfg.headers,
+            ...opts.headers,
+          },
+          method: opts.method,
+          data: opts.body,
+        })
+
+        return data
+      } catch (err) {
+        console.error(`[client.request] ${_opts.method} to ${_url.toString()} failed: ${err.message}`)
+        throw err
+      }
+    },
+  }
+}

--- a/lib/net/post.ts
+++ b/lib/net/post.ts
@@ -1,0 +1,6 @@
+export const Post = (client: Net.Client) => (url: string, opts?: Omit<Net.RequestOpts, "method">) => {
+  return client.request(url, {
+    ...opts,
+    method: "POST",
+  })
+}


### PR DESCRIPTION
in order to start resolving the issues we are facing in prod, i've refactored the http client to make logging http requests a bit easier.