### PR TITLE
feat: Add function do get all assets from Collibra

### DIFF
--- a/GetAssetsTrigger/function.json
+++ b/GetAssetsTrigger/function.json
@@ -1,0 +1,20 @@
+{
+  "bindings": [
+    {
+      "authLevel": "function",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "route": "assets",
+      "methods": [
+        "get"
+      ]
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ],
+  "scriptFile": "../dist/GetAssetsTrigger/index.js"
+}

--- a/GetAssetsTrigger/index.ts
+++ b/GetAssetsTrigger/index.ts
@@ -1,6 +1,5 @@
 import type { AzureFunction, Context, HttpRequest } from "@azure/functions"
 import { Asset } from "@equinor/data-marketplace-models"
-import { AxiosError } from "axios"
 import * as A from "fp-ts/Array"
 import * as TE from "fp-ts/TaskEither"
 import { pipe } from "fp-ts/lib/function"
@@ -8,14 +7,13 @@ import { pipe } from "fp-ts/lib/function"
 import { assetAdapter } from "../lib/collibra/asset_adapter"
 import { getAssetAttributes } from "../lib/collibra/client/get_asset_attributes"
 import { getAssetTypeByName } from "../lib/collibra/client/get_asset_type_by_name"
+import { getAssets } from "../lib/collibra/client/get_assets"
 import { getStatusByName } from "../lib/collibra/client/get_status_id"
 import { makeCollibraClient } from "../lib/collibra/client/make_collibra_client"
 import { makeLogger } from "../lib/logger"
 import { NetError } from "../lib/net/NetError"
-import { Get } from "../lib/net/get"
 import { isErrorResult } from "../lib/net/is_error_result"
 import { makeResult } from "../lib/net/make_result"
-import { toNetErr } from "../lib/net/to_net_err"
 
 const GetAssetsTrigger: AzureFunction = async function (context: Context, req: HttpRequest): Promise<void> {
   const logger = makeLogger(context.log)
@@ -28,19 +26,13 @@ const GetAssetsTrigger: AzureFunction = async function (context: Context, req: H
     TE.bindTo("approvedStatus"),
     TE.bind("dataProductType", () => getAssetTypeByName(collibraClient)("Data Product")),
     TE.bind("assets", ({ approvedStatus, dataProductType }) =>
-      TE.tryCatch(
-        async () => {
-          const { results: assets } = await Get<Collibra.PagedAssetResponse>(collibraClient)("/assets", {
-            params: new URLSearchParams({
-              statusIds: approvedStatus.id,
-              typeIds: dataProductType.id,
-              limit: limit ?? "100",
-              offset: offset ?? "0",
-            }),
-          })
-          return assets
-        },
-        (err: AxiosError) => toNetErr(err.response?.status ?? 500)(err.message)
+      getAssets(collibraClient)(
+        new URLSearchParams({
+          statusIds: approvedStatus.id,
+          typeIds: dataProductType.id,
+          limit: limit ?? "100",
+          offset: offset ?? "0",
+        })
       )
     ),
     TE.chain(({ assets }) =>

--- a/GetAssetsTrigger/index.ts
+++ b/GetAssetsTrigger/index.ts
@@ -15,6 +15,25 @@ import { NetError } from "../lib/net/NetError"
 import { isErrorResult } from "../lib/net/is_error_result"
 import { makeResult } from "../lib/net/make_result"
 
+/**
+ * @openapi
+ * /api/assets
+ * get:
+ *  summary: Get all Assets
+ *  parameters:
+ *    - in: query
+ *      name: limit
+ *      schema:
+ *        type: integer
+ *        default: 100
+ *        description: Limit the number of assets returned.
+ *    - in: query
+ *      name: offset
+ *      schema:
+ *        type: integer
+ *        default: 0
+ *        description: Cursor for the current page of results. To get the next page of results, set the offest to 100 if the limit is 100 (which it is by default).
+ */
 const GetAssetsTrigger: AzureFunction = async function (context: Context, req: HttpRequest): Promise<void> {
   const logger = makeLogger(context.log)
   const collibraClient = await makeCollibraClient(req.headers.authorization)()

--- a/GetAssetsTrigger/index.ts
+++ b/GetAssetsTrigger/index.ts
@@ -19,7 +19,9 @@ import { toNetErr } from "../lib/net/to_net_err"
 
 const GetAssetsTrigger: AzureFunction = async function (context: Context, req: HttpRequest): Promise<void> {
   const logger = makeLogger(context.log)
-  const collibraClient = await makeCollibraClient(req.headers.authorization)(logger)
+  const collibraClient = await makeCollibraClient(req.headers.authorization)()
+
+  const { limit, offset } = req.query
 
   const res = await pipe(
     getStatusByName(collibraClient)("Approved"),
@@ -32,6 +34,8 @@ const GetAssetsTrigger: AzureFunction = async function (context: Context, req: H
             params: new URLSearchParams({
               statusIds: approvedStatus.id,
               typeIds: dataProductType.id,
+              limit: limit ?? "100",
+              offset: offset ?? "0",
             }),
           })
           return assets

--- a/GetAssetsTrigger/index.ts
+++ b/GetAssetsTrigger/index.ts
@@ -1,0 +1,72 @@
+import type { AzureFunction, Context, HttpRequest } from "@azure/functions"
+import { Asset } from "@equinor/data-marketplace-models"
+import { AxiosError } from "axios"
+import * as A from "fp-ts/Array"
+import * as TE from "fp-ts/TaskEither"
+import { pipe } from "fp-ts/lib/function"
+
+import { assetAdapter } from "../lib/collibra/asset_adapter"
+import { getAssetAttributes } from "../lib/collibra/client/get_asset_attributes"
+import { getAssetTypeByName } from "../lib/collibra/client/get_asset_type_by_name"
+import { getStatusByName } from "../lib/collibra/client/get_status_id"
+import { makeCollibraClient } from "../lib/collibra/client/make_collibra_client"
+import { makeLogger } from "../lib/logger"
+import { NetError } from "../lib/net/NetError"
+import { Get } from "../lib/net/get"
+import { isErrorResult } from "../lib/net/is_error_result"
+import { makeResult } from "../lib/net/make_result"
+import { toNetErr } from "../lib/net/to_net_err"
+
+const GetAssetsTrigger: AzureFunction = async function (context: Context, req: HttpRequest): Promise<void> {
+  const logger = makeLogger(context.log)
+  const collibraClient = await makeCollibraClient(req.headers.authorization)(logger)
+
+  const res = await pipe(
+    getStatusByName(collibraClient)("Approved"),
+    TE.bindTo("approvedStatus"),
+    TE.bind("dataProductType", () => getAssetTypeByName(collibraClient)("Data Product")),
+    TE.bind("assets", ({ approvedStatus, dataProductType }) =>
+      TE.tryCatch(
+        async () => {
+          const { results: assets } = await Get<Collibra.PagedAssetResponse>(collibraClient)("/assets", {
+            params: new URLSearchParams({
+              statusIds: approvedStatus.id,
+              typeIds: dataProductType.id,
+            }),
+          })
+          return assets
+        },
+        (err: AxiosError) => toNetErr(err.response?.status ?? 500)(err.message)
+      )
+    ),
+    TE.chain(({ assets }) =>
+      pipe(
+        assets,
+        A.map((asset) =>
+          pipe(
+            getAssetAttributes(collibraClient)(asset.id),
+            TE.map((attributes) => assetAdapter({ ...asset, attributes }))
+          )
+        ),
+        TE.sequenceArray
+      )
+    ),
+    TE.match(
+      (err) => {
+        logger.error(err)
+        return makeResult<readonly Asset[], NetError>(err.status ?? 500, err)
+      },
+      (assets) => makeResult<readonly Asset[], NetError>(200, assets)
+    )
+  )()
+
+  context.res = {
+    status: res.status,
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(isErrorResult(res) ? { error: (res.value as Error).message } : res.value),
+  }
+}
+
+export default GetAssetsTrigger

--- a/GetSwaggerSpec/index.ts
+++ b/GetSwaggerSpec/index.ts
@@ -11,6 +11,7 @@ const swaggerJsdoc: AzureFunction = async function (context: Context): Promise<v
       },
     },
     apis: [
+      "./GetAssets/index.ts",
       "./GetAssetTrigger/index.ts",
       "./GetMaintainersTrigger/index.ts",
       "./GetPopularAssetTrigger/index.ts",

--- a/lib/collibra/client/get_assets.ts
+++ b/lib/collibra/client/get_assets.ts
@@ -1,0 +1,15 @@
+import type { AxiosError } from "axios"
+import * as TE from "fp-ts/TaskEither"
+import { pipe } from "fp-ts/function"
+
+import { Get } from "../../net/get"
+import { toNetErr } from "../../net/to_net_err"
+
+export const getAssets = (client: Net.Client) => (params?: URLSearchParams) =>
+  pipe(
+    TE.tryCatch(
+      () => Get<Collibra.PagedAssetResponse>(client)("/assets", { params }),
+      (err: AxiosError) => toNetErr(err.response?.status ?? 500)(err.message)
+    ),
+    TE.map((res) => res.results)
+  )

--- a/lib/collibra/client/make_collibra_client.ts
+++ b/lib/collibra/client/make_collibra_client.ts
@@ -2,7 +2,7 @@ import { getConfigValue } from "../../../config"
 import { Logger } from "../../logger"
 import { makeNetClient } from "../../net/make_net_client"
 
-export const makeCollibraClient = (authorization: string) => async (logger: Logger) =>
+export const makeCollibraClient = (authorization: string) => async (logger?: Logger) =>
   makeNetClient(
     {
       baseURL: `${await getConfigValue("COLLIBRA_BASE_URL")}/rest/2.0`,

--- a/lib/net/make_net_client.ts
+++ b/lib/net/make_net_client.ts
@@ -7,7 +7,7 @@ const DEFAULT_REQUEST_OPTS: Net.RequestOpts = {
   method: "GET",
 }
 
-export const makeNetClient = (cfg: Net.ClientConfig, logger: Logger): Net.Client => {
+export const makeNetClient = (cfg: Net.ClientConfig, logger?: Logger): Net.Client => {
   return {
     request: async <T>(url: string, opts?: Net.RequestOpts): Promise<T> => {
       const _baseURL = new URL(trimTrailingSlash(cfg.baseURL))
@@ -33,11 +33,13 @@ export const makeNetClient = (cfg: Net.ClientConfig, logger: Logger): Net.Client
           params: opts.params,
         })
 
-        logger.info(
-          `[client.request] ${config.method} request to ${
-            config.params ? `${config.url}?${config.params.toString()}` : config.url
-          } responded with ${status} (${statusText})`
-        )
+        if (logger) {
+          logger.info(
+            `[client.request] ${config.method} request to ${
+              config.params ? `${config.url}?${config.params.toString()}` : config.url
+            } responded with ${status} (${statusText})`
+          )
+        }
 
         return data
       } catch (err) {


### PR DESCRIPTION
This pull requests adds an endpoint to get all assets

**To-do**
- [x] Create first draft of function
- [ ] Discuss possible optimizations
- [x] Add sensible default page limit
  - Collibra's `/assets` endpoint accepts a `limit` endpoint that's useful if we want to paginate responses
- [ ] Refactor for readability