### PR TITLE
refactor: Use Collibra's output module to get asset data

### DIFF
--- a/GetAssetsTrigger/getAssets.ts
+++ b/GetAssetsTrigger/getAssets.ts
@@ -1,0 +1,184 @@
+import * as E from "fp-ts/lib/Either"
+import * as TE from "fp-ts/lib/TaskEither"
+import { pipe } from "fp-ts/lib/function"
+
+import { Post } from "../lib/net/post"
+
+type OutputModuleResponse = {
+  assets: {
+    id: string
+    name: string
+    createdAt: number
+    updatedAt: number
+    domains: {
+      communities: {
+        communityId: string
+        communityName: string
+      }[]
+    }[]
+    assetTypes: {
+      assetTypeId: string
+      assetTypeName: string
+    }[]
+    statuses: {
+      statusId: string
+      statusName: string
+    }[]
+    attributes: {
+      attributeId: string
+      attributeValue: string
+      attributeType: {
+        attributeTypeId: string
+        attributeTypeName: string
+      }[]
+    }[]
+    tags: {
+      tagId: string
+      tagName: string
+    }[]
+    responsibilities: {
+      users: {
+        userId?: string
+        firstName?: string
+        lastName?: string
+      }[]
+      groups: {
+        groupId: string
+        groupName: string
+        groupMembers: {
+          memberId: string
+          memberFirstName: string
+          memberLastName: string
+        }[]
+      }[]
+      roles: {
+        roleId: string
+        roleName: string
+      }[]
+    }[]
+  }[]
+}
+
+export const getAssets = (client: Net.Client) =>
+  pipe(
+    TE.tryCatch(
+      () =>
+        Post<Collibra.OutputModuleResponse<OutputModuleResponse>>(client)("/outputModule/export/json", {
+          headers: {
+            "content-type": "application/json",
+          },
+          params: new URLSearchParams({ validationEnabled: "true" }),
+          body: {
+            ViewConfig: {
+              Resources: {
+                Asset: {
+                  name: "assets",
+                  Id: { name: "id" },
+                  CreatedOn: { name: "createdAt" },
+                  LastModified: { name: "updatedAt" },
+                  DisplayName: { name: "name" },
+                  AssetType: {
+                    name: "assetTypes",
+                    Id: { name: "assetTypeId" },
+                    Name: { name: "assetTypeName" },
+                  },
+                  Status: {
+                    name: "status",
+                    Id: { name: "statusId" },
+                    Signifier: { name: "statusName" },
+                  },
+                  StringAttribute: {
+                    name: "attributes",
+                    Id: { name: "attributeId" },
+                    LongExpression: { name: "attributeValue" },
+                    AttributeType: {
+                      name: "attributeType",
+                      Id: { name: "attributeTypeId" },
+                      Name: { name: "attributeTypeName" },
+                    },
+                    Filter: {
+                      Field: {
+                        name: "attributeTypeName",
+                        operator: "IN",
+                        values: ["Description", "Additional Information", "Timeliness"],
+                      },
+                    },
+                  },
+                  Domain: {
+                    name: "domains",
+                    Id: { name: "domainId" },
+                    Name: { name: "domainName" },
+                    Community: {
+                      name: "communities",
+                      Id: { name: "communityId" },
+                      Name: { name: "communityName" },
+                    },
+                  },
+                  Tag: {
+                    name: "tags",
+                    Id: { name: "tagId" },
+                    Name: { name: "tagName" },
+                  },
+                  Responsibility: {
+                    name: "responsibilities",
+                    User: {
+                      name: "users",
+                      Id: { name: "userId" },
+                      FirstName: { name: "firstName" },
+                      LastName: { name: "lastName" },
+                    },
+                    Group: {
+                      name: "group",
+                      Id: { name: "groupId" },
+                      GroupName: { name: "groupName" },
+                      User: {
+                        name: "groupMembers",
+                        Id: { name: "memberId" },
+                        FirstName: { name: "memberFirstName" },
+                        LastName: { name: "memberLastName" },
+                      },
+                    },
+                    Role: {
+                      name: "role",
+                      Id: { name: "roleId" },
+                      Signifier: { name: "roleName" },
+                    },
+                    Filter: {
+                      AND: [
+                        {
+                          Field: {
+                            name: "roleName",
+                            operator: "IN",
+                            values: ["Data Steward", "Technical Steward"],
+                          },
+                        },
+                      ],
+                    },
+                  },
+                  Filter: {
+                    AND: [
+                      {
+                        Field: {
+                          name: "assetTypeName",
+                          operator: "EQUALS",
+                          value: "Data Product",
+                        },
+                      },
+                      {
+                        Field: {
+                          name: "statusName",
+                          operator: "EQUALS",
+                          value: "Approved",
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          },
+        }),
+      E.toError
+    ),
+    TE.map((res) => res.view.assets)
+  )

--- a/GetAssetsTrigger/index.ts
+++ b/GetAssetsTrigger/index.ts
@@ -1,21 +1,17 @@
 import type { AzureFunction, Context, HttpRequest } from "@azure/functions"
 import { Asset } from "@equinor/data-marketplace-models"
-import * as A from "fp-ts/Array"
 import * as TE from "fp-ts/TaskEither"
 import { pipe } from "fp-ts/lib/function"
 
-import { assetAdapter } from "../lib/collibra/asset_adapter"
-import { getAssetAttributes } from "../lib/collibra/client/get_asset_attributes"
-import { getAssetTags } from "../lib/collibra/client/get_asset_tags"
-import { getAssetTypeByName } from "../lib/collibra/client/get_asset_type_by_name"
-import { getAssets } from "../lib/collibra/client/get_assets"
-import { getCommunityByDomainID } from "../lib/collibra/client/get_community_by_domainid"
-import { getStatusByName } from "../lib/collibra/client/get_status_id"
 import { makeCollibraClient } from "../lib/collibra/client/make_collibra_client"
+import { htmlToPortableText } from "../lib/html_to_portable_text"
 import { makeLogger } from "../lib/logger"
 import { NetError } from "../lib/net/NetError"
 import { isErrorResult } from "../lib/net/is_error_result"
 import { makeResult } from "../lib/net/make_result"
+import { toNetError } from "../lib/net/to_net_err"
+
+import { getAssets } from "./getAssets"
 
 /**
  * @openapi
@@ -38,37 +34,46 @@ import { makeResult } from "../lib/net/make_result"
  */
 const GetAssetsTrigger: AzureFunction = async function (context: Context, req: HttpRequest): Promise<void> {
   const logger = makeLogger(context.log)
-  const collibraClient = await makeCollibraClient(req.headers.authorization)()
+  const collibraClient = await makeCollibraClient(req.headers.authorization)(logger)
 
-  const { limit, offset } = req.query
+  // const { limit, offset } = req.query
 
   const res = await pipe(
-    getStatusByName(collibraClient)("Approved"),
-    TE.bindTo("approvedStatus"),
-    TE.bind("dataProductType", () => getAssetTypeByName(collibraClient)("Data Product")),
-    TE.bind("assets", ({ approvedStatus, dataProductType }) =>
-      getAssets(collibraClient)(
-        new URLSearchParams({
-          statusIds: approvedStatus.id,
-          typeIds: dataProductType.id,
-          limit: limit ?? "100",
-          offset: offset ?? "0",
-        })
-      )
-    ),
-    TE.chain(({ assets }) =>
-      pipe(
-        assets,
-        A.map((asset) =>
-          pipe(
-            getAssetAttributes(collibraClient)(asset.id),
-            TE.bindTo("attributes"),
-            TE.bind("community", () => getCommunityByDomainID(collibraClient)(asset.domain.id)),
-            TE.bind("tags", () => getAssetTags(collibraClient)(asset.id)),
-            TE.map(({ attributes, community, tags }) => assetAdapter(attributes)(community)(tags)(asset))
-          )
-        ),
-        TE.sequenceArray
+    TE.of(collibraClient),
+    TE.bind("assets", getAssets),
+    TE.mapLeft(toNetError(500)),
+    TE.map(({ assets }) =>
+      assets.flatMap(
+        (asset) =>
+          ({
+            community: {
+              id: asset.domains[0]?.communities[0]?.communityId ?? "",
+              name: asset.domains[0]?.communities[0]?.communityName ?? "",
+            },
+            createdAt: asset.createdAt,
+            description: htmlToPortableText(
+              asset.attributes.find((attr) => attr.attributeType[0]?.attributeTypeName === "Additional Information")
+                ?.attributeValue ?? ""
+            ),
+            id: asset.id,
+            name: asset.name,
+            provider: { id: "", name: "Collibra" },
+            qualityScore: 0.0,
+            rating: 0.0,
+            type: {
+              id: asset.assetTypes[0]?.assetTypeId ?? "",
+              name: asset.assetTypes[0]?.assetTypeName ?? "",
+            },
+            updatedAt: asset.updatedAt,
+            updateFrequency: htmlToPortableText(
+              asset.attributes.find((attr) => attr.attributeType[0]?.attributeTypeName === "Timeliness")
+                ?.attributeValue ?? ""
+            ),
+            excerpt: htmlToPortableText(
+              asset.attributes.find((attr) => attr.attributeType[0]?.attributeTypeName === "Description")
+                ?.attributeValue ?? ""
+            ),
+          } as Asset)
       )
     ),
     TE.match(

--- a/collibra.d.ts
+++ b/collibra.d.ts
@@ -525,6 +525,10 @@ declare namespace Collibra {
   }
   export type PagedTagResponse = PagedResponse<Tag>
 
+  export type OutputModuleResponse<T = unknown> = {
+    view: T
+  }
+
   export type WorkflowInstance = Resource & {
     workflowDefinition: WorkflowDefinitionReference
     subInstances: any[]

--- a/lib/net/make_net_client.ts
+++ b/lib/net/make_net_client.ts
@@ -24,6 +24,7 @@ export const makeNetClient = (cfg: Net.ClientConfig, logger?: Logger): Net.Clien
           ...(cfg?.headers ?? {}),
           ...(opts?.headers ?? {}),
         },
+        data: opts?.body,
       }
 
       try {

--- a/lib/net/post.ts
+++ b/lib/net/post.ts
@@ -1,6 +1,9 @@
-export const Post = (client: Net.Client) => (url: string, opts?: Omit<Net.RequestOpts, "method">) => {
-  return client.request(url, {
-    ...opts,
-    method: "POST",
-  })
-}
+export const Post =
+  <T = unknown, B = unknown>(client: Net.Client) =>
+  (url: string, opts?: Omit<Net.RequestOpts, "method">) => {
+    return client.request<T>(url, {
+      ...opts,
+      body: opts?.body as B,
+      method: "POST",
+    })
+  }


### PR DESCRIPTION
**NOTE: This is only proof of concept so far**

Replaced calls to Collibra's REST API to get all approved data products, their attributes, maintainers, tags etc. with one call to the output module endpoint (a GraphQL-like endpoint)

Initial testing seems to have reduced the response time 10x; prod response time is around 10 seconds, and this new implementation responds in around 1 second 🤯🚀